### PR TITLE
Fix ManyToMany admin panel

### DIFF
--- a/teamModule/admin.py
+++ b/teamModule/admin.py
@@ -19,7 +19,7 @@ class ExtraInfoInline(admin.StackedInline):
 class PageMemberAdmin(admin.ModelAdmin):
     model = Member
     inlines = (ExtraInfoInline,)
-    filter_horizontal = ("teamRoles","projects",)
+    filter_horizontal = ("teamRoles", "projects",)
 
 
 class PageFormationAdmin(admin.ModelAdmin):
@@ -46,10 +46,7 @@ admin.site.register(ProjectStatus, PageStatusAdmin)
 admin.site.register(Formation, PageFormationAdmin)
 admin.site.register(Team, PageTeamAdmin)
 admin.site.register(Project, PageProjectsAdmin)
-admin.site.register(TeamRole,PageTeamAdmin)
-admin.site.register(Member, PageMemberAdmin)
-admin.site.register(Formation, PageFormationAdmin)
-admin.site.register(ProjectStatus, PageStatusAdmin)
 admin.site.register(TeamRole, PageTeamRoleAdmin)
 admin.site.register(MemberExtraInfo, PageMemberExtraInfoAdmin)
 admin.site.register(MemberExtraInfoType, PageMemberExtraInfoTypeAdmin)
+admin.site.register(Member, PageMemberAdmin)

--- a/teamModule/admin.py
+++ b/teamModule/admin.py
@@ -19,7 +19,7 @@ class ExtraInfoInline(admin.StackedInline):
 class PageMemberAdmin(admin.ModelAdmin):
     model = Member
     inlines = (ExtraInfoInline,)
-    exclude = ("extraInfos",)
+    filter_horizontal = ("teamRoles","projects",)
 
 
 class PageFormationAdmin(admin.ModelAdmin):
@@ -42,8 +42,11 @@ class PageMemberExtraInfoTypeAdmin(admin.ModelAdmin):
     pass
 
 
+admin.site.register(ProjectStatus, PageStatusAdmin)
+admin.site.register(Formation, PageFormationAdmin)
 admin.site.register(Team, PageTeamAdmin)
 admin.site.register(Project, PageProjectsAdmin)
+admin.site.register(TeamRole,PageTeamAdmin)
 admin.site.register(Member, PageMemberAdmin)
 admin.site.register(Formation, PageFormationAdmin)
 admin.site.register(ProjectStatus, PageStatusAdmin)


### PR DESCRIPTION
Avant, on pouvait juste ajouter des teamroles et projects (sans les linker à l'utilisateur).

J'ai corriger ça en modifier l'admin panel.

Voici le résultat:
![image](https://user-images.githubusercontent.com/9197078/36517905-2d967a82-1752-11e8-8bf9-dd5675a3effc.png)
