### PR TITLE
Feature/fix errors for safari

### DIFF
--- a/teamModule/static/js/project.js
+++ b/teamModule/static/js/project.js
@@ -1,56 +1,58 @@
-
 if (!window.ProjectModuleClass) {
-
-    function ProjectModuleClass(projects, rootId){
+    function ProjectModuleClass(projects, rootId) {
         //This node is the only thing that makes this module unique
         this.rootNode = document.getElementById(rootId);
         this.detailNode = this.rootNode.querySelector(".projectModule__detail");
 
-        this.classes ={
+        this.classes = {
             project: "",
         };
 
         this.detail = {
-            title_parent : this.detailNode.querySelector(".projectModule__detail__title"),
+            title_parent: this.detailNode.querySelector(".projectModule__detail__title"),
             title: this.detailNode.querySelector(".projectModule__detail__title__container"),
-            pictures_parent : this.detailNode.querySelector(".projectModule__detail__pictures"),
+            pictures_parent: this.detailNode.querySelector(".projectModule__detail__pictures"),
             pictures: this.detailNode.querySelector(".projectModule__detail__pictures"),
-            description_parent : this.detailNode.querySelector(".projectModule__detail__description"),
+            description_parent: this.detailNode.querySelector(".projectModule__detail__description"),
             description: this.detailNode.querySelector(".projectModule__detail__description__container"),
             status_parent: this.detailNode.querySelector(".projectModule__detail__status"),
             status: this.detailNode.querySelector(".projectModule__detail__status__container"),
             link_parent: this.detailNode.querySelector(".projectModule__detail__link"),
             link: this.detailNode.querySelector(".projectModule__detail__link__container"),
-            pictureDivStr : "projectModule__detail__picture",
-            pictureActiveStr : "projectModule__detail__picture__active",
-            pictureImgStr : "projectModule__detail__picture__container",
-            blurContainer : this.rootNode.querySelector(".projectModule__detail__blur"),
+            pictureDivStr: "projectModule__detail__picture",
+            pictureActiveStr: "projectModule__detail__picture__active",
+            pictureImgStr: "projectModule__detail__picture__container",
+            blurContainer: this.rootNode.querySelector(".projectModule__detail__blur"),
             closeBtn: this.rootNode.querySelector(".projectModule__detail__close")
         }
 
         this.projects = projects || [];
     }
+}
 
-    ProjectModuleClass.prototype._getProjectById = function(projectId){ 
-        if(this.projects == null || this.projects.length < 1){ 
-            return null; 
-        } 
- 
-        for(var i = 0; i < this.projects.length; i++){ 
-            var project = this.projects[i]; 
-            if(project.id != null && project.id == projectId){ 
-                return project; 
-            } 
-        } 
-        return null; 
-    } 
+if (!ProjectModuleClass.prototype._getProjectById) {
+    ProjectModuleClass.prototype._getProjectById = function (projectId) {
+        if (this.projects == null || this.projects.length < 1) {
+            return null;
+        }
 
-    ProjectModuleClass.prototype.setActiveProject = function(projectId){
+        for (var i = 0; i < this.projects.length; i++) {
+            var project = this.projects[i];
+            if (project.id != null && project.id == projectId) {
+                return project;
+            }
+        }
+        return null;
+    }
+}
+
+if (!ProjectModuleClass.prototype.setActiveProject) {
+    ProjectModuleClass.prototype.setActiveProject = function (projectId) {
         var project = this._getProjectById(projectId);
         //console.log(project);
         this.activeProjectDetail = project;
         //console.log("setActiveProject", projectId);
-        if(project == null){
+        if (project == null) {
             $(this.detail.pictures).owlCarousel('destroy');
             this.detail.title.innerText = '';
             this.detail.pictures.innerHTML = '';
@@ -75,7 +77,7 @@ if (!window.ProjectModuleClass) {
         this.detail.link.innerText = project.website;
         this.showHideInfo(this.detail.link_parent, !this.empty(project.website));
 
-        for(var i = 0; i < project.images.length; i++){
+        for (var i = 0; i < project.images.length; i++) {
             this._insertPicture(this.detail.pictures, project.images[i]);
         }
         var _this = this;
@@ -86,49 +88,57 @@ if (!window.ProjectModuleClass) {
         this.detail.closeBtn.style.display = "block";
         this.calculateClosePosition();
     }
+}
 
-    ProjectModuleClass.prototype.calculateClosePosition = function(){
+if (!ProjectModuleClass.prototype.calculateClosePosition) {
+    ProjectModuleClass.prototype.calculateClosePosition = function () {
         var rect = this.detailNode.getBoundingClientRect();
         //alert(JSON.stringify(rect));
         this.detail.closeBtn.style.top = (rect.top + 10) + "px";
-        this.detail.closeBtn.style.right = ((rect.right - rect.width) + 10) + "px" ;
+        this.detail.closeBtn.style.right = ((rect.right - rect.width) + 10) + "px";
     }
+}
 
-    ProjectModuleClass.prototype.showHideInfo = function(component, show){
-        if(show && component == this.detail.description_parent){
+if (!ProjectModuleClass.prototype.showHideInfo) {
+    ProjectModuleClass.prototype.showHideInfo = function (component, show) {
+        if (show && component == this.detail.description_parent) {
             component.style.display = "contents";
-        } else if(show){
+        } else if (show) {
             component.style.display = "block";
         } else {
             component.style.display = "none";
         }
     }
-    ProjectModuleClass.prototype.empty = function(data)
-    {
-      if(typeof(data) == 'number' || typeof(data) == 'boolean'){ 
-        return false; 
-      }
-      if(typeof(data) == 'undefined' || data === null){
-        return true; 
-      }
-      if(typeof(data.length) != 'undefined'){
-        return data.length == 0;
-      }
-      var count = 0;
-      for(var i in data){
-        if(data.hasOwnProperty(i))
-        {
-          count ++;
+}
+if (!ProjectModuleClass.prototype.empty) {
+    ProjectModuleClass.prototype.empty = function (data) {
+        if (typeof(data) == 'number' || typeof(data) == 'boolean') {
+            return false;
         }
-      }
-      return count == 0;
+        if (typeof(data) == 'undefined' || data === null) {
+            return true;
+        }
+        if (typeof(data.length) != 'undefined') {
+            return data.length == 0;
+        }
+        var count = 0;
+        for (var i in data) {
+            if (data.hasOwnProperty(i)) {
+                count++;
+            }
+        }
+        return count == 0;
     }
+}
 
-    ProjectModuleClass.prototype.closeModal = function(){
+if (!ProjectModuleClass.prototype.closeModal) {
+    ProjectModuleClass.prototype.closeModal = function () {
         this.setActiveProject(null);
     }
+}
 
-    ProjectModuleClass.prototype._insertPicture = function(parentNode, imageUrl){
+if (!ProjectModuleClass.prototype._insertPicture) {
+    ProjectModuleClass.prototype._insertPicture = function (parentNode, imageUrl) {
         var div = document.createElement("div");
         div.classList.add(this.detail.pictureDivStr);
 
@@ -139,23 +149,25 @@ if (!window.ProjectModuleClass) {
 
         parentNode.appendChild(div);
     }
+}
 
-    ProjectModuleClass.prototype.buildCarousel = function(){
+if (!ProjectModuleClass.prototype.buildCarousel) {
+    ProjectModuleClass.prototype.buildCarousel = function () {
         var moreThanOnePicture = false;
-        if(!this.empty(this.activeProjectDetail)){
+        if (!this.empty(this.activeProjectDetail)) {
             moreThanOnePicture = (this.activeProjectDetail.images.length > 1);
         }
         $(this.detail.pictures).owlCarousel({
             center: true,
             loop: moreThanOnePicture,
-            items:1,
+            items: 1,
             navigation: false,
             slideSpeed: 300,
             paginationSpeed: 400,
             margin: 1,
-            autoplay:true,
-            autoplayTimeout:5000,
-            autoplayHoverPause:true
+            autoplay: true,
+            autoplayTimeout: 5000,
+            autoplayHoverPause: true
         });
     }
 }

--- a/teamModule/static/js/team_display.js
+++ b/teamModule/static/js/team_display.js
@@ -3,7 +3,8 @@ if (!window._TeamModuleHelper) {
     function _TeamModuleHelper() {
 
     }
-
+}
+if (!_TeamModuleHelper.prototype.indexArrayByKey) {
     _TeamModuleHelper.prototype.indexArrayByKey = function (arr, key) {
         var map = {};
         for (var i = 0; i < arr.length; i++) {
@@ -12,6 +13,9 @@ if (!window._TeamModuleHelper) {
         }
         return map;
     };
+}
+
+if (!window.TeamModuleHelper) {
     TeamModuleHelper = new _TeamModuleHelper();
 }
 
@@ -85,7 +89,7 @@ if (!window.TeamModuleClass) {
         }
 
         //Reset active member
-        if(this.activeDataTypes.member.id){
+        if (this.activeDataTypes.member.id) {
             this.setActiveMember(this.activeDataTypes.member.id);
         }
     };
@@ -107,8 +111,8 @@ if (!window.TeamModuleClass) {
                 this._loadMemberDetails(null);
             }
             if (id !== null) {
-                nameElem =  nameElem ? nameElem : this.rootNode.querySelector("." + this.classByType.member + id);
-                iconElem =  iconElem ? iconElem : this.rootNode.querySelector("." + this.classByType.memberIcon + id);
+                nameElem = nameElem ? nameElem : this.rootNode.querySelector("." + this.classByType.member + id);
+                iconElem = iconElem ? iconElem : this.rootNode.querySelector("." + this.classByType.memberIcon + id);
                 this._setActiveDiv(nameElem, 'member', true);
                 this._setActiveDiv(iconElem, 'memberIcon', true);
                 this._loadMemberDetails(id);

--- a/teamModule/static/js/team_display.js
+++ b/teamModule/static/js/team_display.js
@@ -61,7 +61,9 @@ if (!window.TeamModuleClass) {
         this.setActiveMember = this.setActiveMember.bind(this);
         this.setActiveTeam = this.setActiveTeam.bind(this);
     }
+}
 
+if (!TeamModuleClass.prototype.resetActiveDataType) {
     TeamModuleClass.prototype.resetActiveDataType = function (type) {
         if (this.activeDataTypes.hasOwnProperty(type)) {
             this.activeDataTypes[type] = {
@@ -70,7 +72,9 @@ if (!window.TeamModuleClass) {
             };
         }
     };
+}
 
+if (!TeamModuleClass.prototype.setActiveTeam) {
     TeamModuleClass.prototype.setActiveTeam = function (teamId, elem) {
         if (this.activeDataTypes.team.id === teamId) {
             this._setActiveDiv(this.activeDataTypes.team.elem, 'team', false);
@@ -93,8 +97,9 @@ if (!window.TeamModuleClass) {
             this.setActiveMember(this.activeDataTypes.member.id);
         }
     };
+}
 
-
+if (!TeamModuleClass.prototype.setActiveMember) {
     TeamModuleClass.prototype.setActiveMember = function (id, nameElem, iconElem) {
         if (this.activeDataTypes.member.id === id) {
             nameElem = nameElem ? nameElem : this.rootNode.querySelector('.' + this.classByType.member + id);
@@ -121,7 +126,8 @@ if (!window.TeamModuleClass) {
             this.activeDataTypes.member.elem = nameElem;
         }
     };
-
+}
+if (!TeamModuleClass.prototype.setMemberVisibility) {
     TeamModuleClass.prototype.setMemberVisibility = function (teamId) {
         for (var i = 0; i < this.members.length; i++) {
             var member = this.members[i];
@@ -138,6 +144,9 @@ if (!window.TeamModuleClass) {
         }
     };
 
+}
+
+if (!TeamModuleClass.prototype.isPartOfTeam) {
     TeamModuleClass.prototype.isPartOfTeam = function (member, teamId) {
         if (teamId === -1) {
             return true;
@@ -151,7 +160,8 @@ if (!window.TeamModuleClass) {
             return false;
         }
     };
-
+}
+if (!TeamModuleClass.prototype._loadMemberDetails) {
     /**
      * @private
      */
@@ -182,7 +192,9 @@ if (!window.TeamModuleClass) {
             mapping.formation.innerText = member.formation.name;
         }
     };
+}
 
+if (!TeamModuleClass.prototype._setActiveDiv) {
     /**
      * @private
      */

--- a/teamModule/static/js/team_display.js
+++ b/teamModule/static/js/team_display.js
@@ -185,7 +185,7 @@ if (!TeamModuleClass.prototype._loadMemberDetails) {
             for (var i = 0; i < member.projects.length; i++) {
                 var project = member.projects[i];
                 var projectContainer = document.createElement('div');
-                var node = document.createTextNode(project.project_name);
+                var node = document.createTextNode(project.name);
                 projectContainer.appendChild(node);
                 projectElement.appendChild(projectContainer);
             }


### PR DESCRIPTION
For some reasons, Safari was keeping a cache of our Class objects.

The conditional definition of our class was not redeclaring the prototypes. To fix this, I added condition declaring for each of the prototypes. 

I could have overwrite the class everytime a plugin is inserted but that would have been greedy a bit.