### PR TITLE
Reduce spacing for footer elements

### DIFF
--- a/static/style/footer.scss
+++ b/static/style/footer.scss
@@ -12,6 +12,7 @@
     display: flex;
     justify-content: space-between;
     width: 100%;
+    padding: 0 33px;
     max-width: $width-xl;
 
     @include breakpoint(tablet) {
@@ -36,7 +37,6 @@
   }
 
   &__section {
-    margin: 0 33px;
   }
 
   &__icon {


### PR DESCRIPTION
There was too much spacing between footer elements. I added horizontal padding on the parent instead of margins on each elements.

Before/after
![image](https://user-images.githubusercontent.com/9197078/55514201-7d7b5180-5635-11e9-8908-ba8946a41ef0.png)
