### PR TITLE
Fallback to french when loading translatable models

### DIFF
--- a/website/settings.py
+++ b/website/settings.py
@@ -180,8 +180,8 @@ INSTALLED_APPS = (
 
 LANGUAGES = (
     ## Customize this
-    ('en', _('en')),
     ('fr', _('fr')),
+    ('en', _('en')),
 )
 
 CMS_LANGUAGES = {
@@ -193,16 +193,16 @@ CMS_LANGUAGES = {
     },
     1: [
         {
-            'code': 'en',
-            'name': _('English'),
+            'code': 'fr',
+            'name': _('French'),
+            'fallbacks': ['en'],
             'redirect_on_fallback': True,
             'public': True,
             'hide_untranslated': False,
         },
         {
-            'code': 'fr',
-            'name': _('French'),
-            'fallbacks': ['en'],
+            'code': 'en',
+            'name': _('English'),
             'redirect_on_fallback': True,
             'public': True,
             'hide_untranslated': False,


### PR DESCRIPTION
By default, the language fallback of translatable models was english. So if we were fetching members without english translations, it would fail. instead, I fallback to french translations since they're always defined.