### PR TITLE
Fix project description height + title height

### DIFF
--- a/teamModule/templates/projectModule/project_display.html
+++ b/teamModule/templates/projectModule/project_display.html
@@ -52,9 +52,9 @@
                     <img class="projectModule__projects__project__picture__container projectModule__projects__project__picture__container--default"/>
                 {% endif %}
             </div>
-            <div class="projectModule__projects__project__title">
+            <h2 class="projectModule__projects__project__title">
                 {{ project.name }}
-            </div>
+            </h2>
             <div class="projectModule__projects__project__layer"></div>
             </div>
             {% endfor %}
@@ -82,7 +82,7 @@
 
             <div class="projectModule__detail__right">
                 <div class="projectModule__detail__title">
-                    <h2 class="projectModule__detail__title__container"> {{ translations.project_title }}</h2>
+                    <div class="projectModule__detail__title__container"> {{ translations.project_title }}</div>
                 </div>
 
                 <div class="projectModule__detail__description">

--- a/website/static/style/basic/_fonts.scss
+++ b/website/static/style/basic/_fonts.scss
@@ -8,9 +8,9 @@ $text-big: 1.2em;
 
 // Title font
 $title-font: 'rawline', 'Arial', 'Ubuntu', sans-serif;
+$title-big: 4.8em;
 $title-regular: 4em;
 $title-small: 2.4em;
-$title-big: 4.8em;
 
 %text {
     font-family: $text-font;

--- a/website/static/style/project_display.scss
+++ b/website/static/style/project_display.scss
@@ -164,6 +164,8 @@ $smLargeDivHeight: 225px;
         -webkit-text-stroke-color: white;
         text-stroke-color: white;
         z-index: 20;
+        margin: 0;
+        font-weight: bold;
 
         @include breakpoint(phone) {
           font-size: $title-small;
@@ -224,7 +226,7 @@ $smLargeDivHeight: 225px;
     top: 5vh;
     width: 90%;
     margin: 0 5%;
-    height:90vh;
+    height: 90vh;
     background-color: $color-background-light;
     border-radius: 7px;
     outline: none; // to remove the blue border when focus on chrome
@@ -241,7 +243,8 @@ $smLargeDivHeight: 225px;
       font-size: $title-small;
 
       &__container {
-
+        font-weight: bold;
+        margin: 0.5em 0;
       }
     }
 
@@ -307,6 +310,7 @@ $smLargeDivHeight: 225px;
       @extend .col-md-45;
       overflow-y: auto;
       padding-top: 0 !important;
+      flex: 1;
 
       & > div {
         display: flex;


### PR DESCRIPTION
Fix a bug where we would have two scrollbar on mobile when opening a project  dialog.
I also changed the height of the titles (they were too big on mobile)

Before: https://cl.ly/5d818cada728
After: https://cl.ly/684dcd25bdaa