### PR TITLE
Fix project display and add team role in member detail

### DIFF
--- a/teamModule/static/js/team_display.js
+++ b/teamModule/static/js/team_display.js
@@ -55,7 +55,7 @@ if (!window.TeamModuleHelper) {
 
 // Register the instance only if not registered
 if (!window.TeamModuleClass) {
-  function TeamModuleClass(members, rootId) {
+  function TeamModuleClass(members, teams, rootId) {
     //This node is the only thing that makes this module unique
     this.rootNode = document.getElementById(rootId);
     this.classByType = {
@@ -71,6 +71,7 @@ if (!window.TeamModuleClass) {
       fullName: this.rootNode.querySelector(".teamModule__details__fullname"),
       bio: this.rootNode.querySelector(".teamModule__details__bio"),
       projects: this.rootNode.querySelector(".teamModule__details__projects"),
+      teamRoles: this.rootNode.querySelector(".teamModule__details__teams"),
       formation: this.rootNode.querySelector(".teamModule__details__formation"),
       blur: this.rootNode.querySelector(".teamModule__details__blur")
     };
@@ -91,6 +92,8 @@ if (!window.TeamModuleClass) {
     };
 
     this.members = members;
+    this.teams = teams;
+    this.teamsById = TeamModuleHelper.indexArrayByKey(teams, 'id');
     this.membersById = TeamModuleHelper.indexArrayByKey(members, 'id');
     this.hiddenClass = "teamModule--hidden";
     this.invisibleClass = "teamModule--invisible";
@@ -220,10 +223,25 @@ if (!TeamModuleClass.prototype._loadMemberDetails) {
       mapping.fullName.innerText = member.first_name + " " + member.last_name;
       mapping.bio.innerText = member.bio;
 
+
+      // Add teams
+      var teamElement = mapping.teamRoles;
+      teamElement.innerHTML = '';
+      for (var i = 0; i < member.teamRoles.length; i++) {
+        var teamRole = member.teamRoles[i];
+        var teamName = this.teamsById[teamRole.team].team_name;
+        var roleName = teamRole.role;
+
+        var roleContainer = document.createElement('div');
+        var node = document.createTextNode(teamName + ' (' + roleName + ')');
+        roleContainer.appendChild(node);
+        teamElement.appendChild(roleContainer);
+      }
+
+      //Add projects
       var projectElement = mapping.projects;
       projectElement.innerHTML = '';
 
-      //Add projects
       for (var i = 0; i < member.projects.length; i++) {
         var project = member.projects[i];
         var projectContainer = document.createElement('div');

--- a/teamModule/templates/projectModule/project_display.html
+++ b/teamModule/templates/projectModule/project_display.html
@@ -49,11 +49,16 @@
       </div>
       <div class="projectModule__projects__project__picture">
         {% if project.images.all %}
-          <img alt="Project image" class="projectModule__projects__project__picture__container"
-               style="background-image:url('{{ project.images.all.0 }}')"/>
+          {% comment %} No alt or src here since we need to load image from CSS {% endcomment %}
+          <img
+            class="projectModule__projects__project__picture__container"
+            style="background-image:url('{{ project.images.all.0 }}')"
+          />
         {% else %}
-          <img alt="Project image"
-            class="projectModule__projects__project__picture__container projectModule__projects__project__picture__container--default"/>
+          {% comment %} No alt or src here since we need to load image from CSS {% endcomment %}
+          <img
+            class="projectModule__projects__project__picture__container projectModule__projects__project__picture__container--default"
+          />
         {% endif %}
       </div>
       <h2 class="projectModule__projects__project__title">

--- a/teamModule/templates/teamModule/team_display.html
+++ b/teamModule/templates/teamModule/team_display.html
@@ -1,74 +1,97 @@
 {% load sekizai_tags compress  static cache_bust %}
-{% load i18n %}
-{% compress css %}
-  <link rel="stylesheet" type="text/x-scss" href="{% static "style/team_display.scss" %}">
-{% endcompress %}
+{% addtoblock "css" %}
+  {% compress css %}
+    <link rel="stylesheet" type="text/x-scss" href="{% static "style/team_display.scss" %}">
+  {% endcompress %}
+{% endaddtoblock %}
 {% addtoblock "js" %}
   <script type="text/javascript" src="{% static "js/team_display.js" %}?{% cache_bust %}"></script>
+  {% compress js %}
+    <script type="text/javascript">
+      //Encapsulate javascript inside a function so it's not accessible from the outside #hackerman
+      var team_{{ uniqueName }};
+      (function () {
+        //Data from the backend
+        var members = {{ membersAsJson|safe}};
+        var teams = {{  teamsAsJson|safe }};
+        //Init the required modules with unique identifier
+        team_{{ uniqueName }} = new TeamModuleClass(members,teams, "{{ uniqueName }}");
+        var allMembersTeam = team_{{ uniqueName }}.rootNode.querySelector(".teamModule__team");
+        team_{{ uniqueName }}.setActiveTeam(-1, allMembersTeam);
+      })();
+
+      $(document).ready(function () {
+        var $dropDown = $('#team_{{ uniqueName }}_dropdown');
+        $dropDown.select2();
+        $dropDown.on('change', function (evt) {
+          team_{{ uniqueName }}.setActiveTeam(parseInt(evt.target.value));
+        });
+      });
+    </script>
+  {% endcompress %}
 {% endaddtoblock %}
-{% addtoblock "js" %}
-  <script type="text/javascript">
-    //Encapsulate javascript inside a function so it's not accessible from the outside #hackerman
-    var {{ uniqueName }};
-    (function () {
-      //Data from the backend
-      var members = {{ membersAsJson|safe}};
-      var teams = {{  teamsAsJson|safe }};
-      //Init the required modules with unique identifier
-      {{ uniqueName }}
-      = new TeamModuleClass(members, "{{ uniqueName }}");
-      var allMembersTeam =
-      {{ uniqueName }}.
-      rootNode.querySelector(".teamModule__team");
-      {{ uniqueName }}.
-      setActiveTeam(-1, allMembersTeam);
-    })();
-  </script>
-{% endaddtoblock %}
-
-
-<div class="teamModule" id="{{ uniqueName }}">
-  <div class="teamModule__panel teamModule__panel--left">
-    <div class="teamModule__teams">
-      <h1 class="teamModule__title">{{ translations.teams_title }}</h1>
-      {% for team in teams %}
-        <div class="teamModule__team" onclick="{{ uniqueName }}.setActiveTeam({{ team.id }},this)">
-          {{ team.team_name }}
-          <span class="teamModule__team__count">{{ team.members_count }}</span>
-        </div>
-      {% endfor %}
-    </div>
-
-    <div class="teamModule__members">
-      <h1 class="teamModule__title">{{ translations.members_title }}</h1>
-      <div class="teamModule__memberpanel teamModule__memberpanel--left">
-        {% for member in members %}
-          <div class="teamModule__team__member teamModule__team__member{{ member.id }}"
-               onclick="{{ uniqueName }}.setActiveMember({{ member.id }},this)">
-            {{ member.first_name }} {{ member.last_name }}
-          </div>
-        {% endfor %}
-      </div>
-      <div class="teamModule__memberpanel teamModule__memberpanel--right">
+<div class="teamModule container-fluid" id="{{ uniqueName }}">
+  <div class="row">
+    <div class="col-xs-0 col-sm-0 col-md-1 col-lg-1"></div>
+    <div class="col-xs-12 col-sm-7 col-md-7 col-lg-8 ">
+      <div class="teamModule__teams">
+        <label for="team_{{ uniqueName }}_dropdown">
+          <h1 class="teamModule__title">{{ translations.teams_title }}</h1>
+        </label>
         <div class="row">
-          {% for member in members %}
-            <img class="teamModule__memberpanel__icon teamModule__memberpanel__icon{{ member.id }}"
-                 src="{{ member.image }}"
-                 alt="{{ member.firstName }}"
-                 onclick="{{ uniqueName }}.setActiveMember({{ member.id }},null,this)"/>
-          {% endfor %}
+          <select id="team_{{ uniqueName }}_dropdown" name="state" class="col-xs-12 col-md-4">
+            {% for team in teams %}
+              <option value="{{ team.id }}"
+                      onClick="team_{{ uniqueName }}.setActiveTeam({{ team.id }},this)">
+                {{ team.team_name }} ({{ team.members_count }})
+              </option>
+            {% endfor %}
+          </select>
+        </div>
+      </div>
+
+      <div class="teamModule__members">
+        <h1 class="teamModule__title">{{ translations.members_title }}</h1>
+        <div class="row">
+
+          <div class="teamModule__memberpanel col-xs-0 col-md-4">
+            {% for member in members %}
+              <div class="teamModule__team__member teamModule__team__member{{ member.id }}"
+                   onclick="team_{{ uniqueName }}.setActiveMember({{ member.id }},this)">
+                {{ member.first_name }} {{ member.last_name }}
+              </div>
+            {% endfor %}
+          </div>
+          <div class="teamModule__memberpanel teamModule__memberpanel--avatars col-md-8 col-xs-12">
+            {% for member in members %}
+              <img class="teamModule__memberpanel__icon teamModule__memberpanel__icon{{ member.id }}"
+                   src="{{ member.image }}"
+                   alt="{{ member.firstName }}"
+                   onclick="team_{{ uniqueName }}.setActiveMember({{ member.id }},null,this)"/>
+            {% endfor %}
+          </div>
         </div>
       </div>
     </div>
-  </div>
-  <div class="teamModule__panel teamModule__panel--right teamModule__details teamModule--hidden">
-    <div>
-      <img alt="Team member" class="teamModule__details__picture" src=""/>
+    <div class="teamModule__details__blur teamModule--invisible "
+         onclick="team_{{ uniqueName }}.modalClose()"></div>
+    <div class="teamModule__details teamModule--invisible col-xs-12 col-sm-3 col-md-3 col-lg-2">
+      <div class="teamModule__details__close" onclick="team_{{ uniqueName }}.modalClose()">&times;</div>
+      <div class="center-xs start-sm teamModule__details__sticky">
+        <div>
+          <img alt="Member picture" class="teamModule__details__picture" src=""/>
+        </div>
+        <div class="teamModule__details__fullname"></div>
+        <h4></h4>
+        <div class="teamModule__details__bio"></div>
+         <span class="teamModule__details__section__title">{{ translations.teams_title }}</span>
+        <div class="teamModule__details__teams"></div>
+        <span class="teamModule__details__section__title">{{ translations.projects_title }}</span>
+        <div class="teamModule__details__projects"></div>
+        <span class="teamModule__details__section__title">{{ translations.formation_title }}</span>
+        <div class="teamModule__details__formation"></div>
+      </div>
     </div>
-    <div class="teamModule__details__fullname"></div>
-    <h4>{{ translations.projects_title }}</h4>
-    <div class="teamModule__details__projects"></div>
-    <h4>{{ translations.formation_title }}</h4>
-    <div class="teamModule__details__formation"></div>
+    <div class="col-xs-0 col-sm-0 col-md-1 col-lg-1"></div>
   </div>
 </div>

--- a/website/templates/components/team_display.html
+++ b/website/templates/components/team_display.html
@@ -15,7 +15,7 @@
         var members = {{ membersAsJson|safe}};
         var teams = {{  teamsAsJson|safe }};
         //Init the required modules with unique identifier
-        team_{{ uniqueName }} = new TeamModuleClass(members, "{{ uniqueName }}");
+        team_{{ uniqueName }} = new TeamModuleClass(members,teams, "{{ uniqueName }}");
         var allMembersTeam = team_{{ uniqueName }}.rootNode.querySelector(".teamModule__team");
         team_{{ uniqueName }}.setActiveTeam(-1, allMembersTeam);
       })();
@@ -84,6 +84,8 @@
         <div class="teamModule__details__fullname"></div>
         <h4></h4>
         <div class="teamModule__details__bio"></div>
+         <span class="teamModule__details__section__title">{{ translations.teams_title }}</span>
+        <div class="teamModule__details__teams"></div>
         <span class="teamModule__details__section__title">{{ translations.projects_title }}</span>
         <div class="teamModule__details__projects"></div>
         <span class="teamModule__details__section__title">{{ translations.formation_title }}</span>


### PR DESCRIPTION
# Project display bug fix

Since there was no `src` attribute for the images in Project display, it was defaulting on the `alt` attribute. So I removed the `src` and `alt` attributes.

# Add team role

When you click on a member, I show the list of teams that the member is in. I also add the role as a suffix.

Desktop:
![image](https://user-images.githubusercontent.com/9197078/61605661-932c7b00-ac14-11e9-8c1f-dd92fd3e637c.png)

Mobile:
![image](https://user-images.githubusercontent.com/9197078/61605651-89a31300-ac14-11e9-9724-636b3e0a21e2.png)
